### PR TITLE
ci/github: Set SOURCE_DATE_EPOCH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: quay.io/centos-boot/builder:latest@sha256:1d4eb0aff4fc11274b19fade0c380de6c3e4a3ec3786a824c3ed49cb5e397b84
+      image: quay.io/centos-boot/builder:latest
       options: --privileged
 
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
+      - name: Workaround git safe.directory
+        run: git config --global --add safe.directory '*'
+
+      - name: Set SOURCE_DATE_EPOCH
+        run: echo SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) >> $GITHUB_ENV
+
       - name: Build
         run: |
           rpm-ostree compose image --format=ociarchive \

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -34,6 +34,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
+      # The --privileged bits seem to trip this up
+      - name: Ensure git safe directory
+        run: git config --global --add safe.directory '*'
+
+      - name: Set SOURCE_DATE_EPOCH
+        run: echo SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) >> $GITHUB_ENV
+
       - name: Build and Push
         run: |
           echo "${{ secrets.QUAY_PASSWORD }}" | skopeo login -u "${{ secrets.QUAY_USER }}" \


### PR DESCRIPTION
This is important since it turns on some rpm-ostree reproducibility bits. TODO: replicate with RHTAP