### PR TITLE
Unpin builder image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: quay.io/centos-boot/builder:1.0.0@sha256:d5e7caf5fcb0e38b0311bff19e087c527f464173f6bebfa47b0506a31688197a
+      image: quay.io/centos-boot/builder:latest
       options: --privileged
 
     strategy:

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: quay.io/centos-boot/builder:1.0.0@sha256:d5e7caf5fcb0e38b0311bff19e087c527f464173f6bebfa47b0506a31688197a
+      image: quay.io/centos-boot/builder:latest
       options: --privileged
 
     strategy:

--- a/.tekton/ostree-build.yaml
+++ b/.tekton/ostree-build.yaml
@@ -206,7 +206,7 @@ spec:
         - name: PLATFORM
           value: linux/amd64
         - name: BUILDER_IMAGE
-          value: quay.io/centos-boot/builder:1.0.0
+          value: quay.io/centos-boot/builder:latest
       runAfter:
         - clone-repository
       taskRef:
@@ -241,7 +241,7 @@ spec:
         - name: PLATFORM
           value: linux/arm64
         - name: BUILDER_IMAGE
-          value: quay.io/centos-boot/builder:1.0.0
+          value: quay.io/centos-boot/builder:latest
       runAfter:
         - clone-repository-arm64
       taskRef:
@@ -276,7 +276,7 @@ spec:
         - name: PLATFORM
           value: linux/s390x
         - name: BUILDER_IMAGE
-          value: quay.io/centos-boot/builder:1.0.0
+          value: quay.io/centos-boot/builder:latest
       runAfter:
         - clone-repository-s390x
       taskRef:


### PR DESCRIPTION
Let's assume for now that our own builder image isn't going to break us.  This is needed to unblock getting `git` in the image which we need for other things.

At some point yes we can investigate renovate for this potentially but I'd rather say that we have decent CI around the builder image.