### PR TITLE
Also build c9s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,13 @@ jobs:
 
     strategy:
       matrix:
-        os: [fedora]
+        os: [fedora, centos]
         tier: [tier-1]
         include:
         - os: fedora
           version: eln
+        - os: centos
+          version: stream9
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -24,11 +24,13 @@ jobs:
 
     strategy:
       matrix:
-        os: [fedora]
+        os: [fedora, centos]
         tier: [tier-1]
         include:
         - os: fedora
           version: eln
+        - os: centos
+          version: stream9
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Fedora ELN has a few bugs (e.g. the kernel dropped iptables support which breaks podman), we will also target c9s.